### PR TITLE
Don't overwrite top level propery options

### DIFF
--- a/src/components/VimeoPlayer.svelte
+++ b/src/components/VimeoPlayer.svelte
@@ -60,7 +60,7 @@
   }
 
   onMount(async () => {
-    const options = {
+    const overrides = {
       id: videoId,
       width: playerWidth,
       height: playerHeight,
@@ -68,7 +68,7 @@
       autoplay: autoplay
     }
 
-    vimeo = new Player(elementId, assign(options, options))
+    vimeo = new Player(elementId, assign(options, overrides))
     player = new Proxy(vimeo, handler)
 
     setEvents()


### PR DESCRIPTION
Also solves:

```
VimeoPlayer has unused export property 'options'. If it is for external reference only, please consider using `export const 'options'`
 8:   export let playerHeight = 320;
 9:   export let playerWidth = 640;
10:   export let options = () => ({});
                 ^
11:   export let videoId;
12:   export let loop = false;
```