### PR TITLE
Ensure Player is defined before unloading

### DIFF
--- a/src/components/VimeoPlayer.svelte
+++ b/src/components/VimeoPlayer.svelte
@@ -75,7 +75,9 @@
   });
 
   onDestroy(() => {
-    player.unload()
+    if (player) {
+      player.unload();
+    }
   });
 </script>
 


### PR DESCRIPTION
I also ran into the error mentioned at #3 while using this library with Sapper. This address it by ensuring the player object is defined before trying to unload it.